### PR TITLE
Added db attribute to tables. Improved selectx self ref handling.

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Revision history for MySQL-ORM
         - Fixed selectx method generation to handle self referencing tables.
           Current solution was to not support selectx fetching the parent table
           attributes when the parent table == current table.
+        - Better handling of dbh clone
 
 0.14    - Added dbh clone disconnect on destroy logic to avoid warning messages
           if the clone was created while autocommit was off or a transaction

--- a/Changes
+++ b/Changes
@@ -1,6 +1,13 @@
 Revision history for MySQL-ORM
 
 =======
+0.15    - Added a db attribute to the table classes in order to maintain a link
+          back to the orm class. Mainly useful in CustomRoles which want to make
+          use of methods defined in other CustomRoles on different tables.
+        - Fixed selectx method generation to handle self referencing tables.
+          Current solution was to not support selectx fetching the parent table
+          attributes when the parent table == current table.
+
 0.14    - Added dbh clone disconnect on destroy logic to avoid warning messages
           if the clone was created while autocommit was off or a transaction
           was open.

--- a/lib/MySQL/ORM.pm
+++ b/lib/MySQL/ORM.pm
@@ -9,7 +9,7 @@ use Data::Printer alias => 'pdump';
 use SQL::Abstract::Complete;
 use MySQL::Util::Lite;
 
-our $VERSION = '0.14';
+our $VERSION = '0.15';
 
 =head1 SYNOPSIS
 
@@ -94,6 +94,17 @@ has _prune_ddl => (
 # public methods
 ##############################################################################
 
+method begin_work(){
+    $self->dbh->begin_work;
+}
+
+method rollback(){
+    $self->dbh->rollback;   
+}
+
+method commit(){
+    $self->dbh->commit;   
+}
 
 =head1 SUBROUTINES/METHODS
 

--- a/lib/MySQL/ORM.pm
+++ b/lib/MySQL/ORM.pm
@@ -63,7 +63,8 @@ has __lite => (
 has _lite_ready => (
     is      => 'rw',
     isa     => 'Bool',
-    default => 0
+    default => 0,
+    init_arg => '_hide'
 );
 
 has _schema => (
@@ -388,24 +389,12 @@ method _build_schema_name {
 method _build__lite {
 	
 	my $schema = $self->schema_name;
-	my $clone = $self->dbh->clone;
+	my $clone = $self->dbh->clone( { InactiveDestroy => 1, ReadOnly => 1 } );
 	$clone->do("use $schema");
 	
 	$self->_lite_ready(1);
 	
 	return MySQL::Util::Lite->new( dbh => $clone, span => 1 );
-}
-
-sub DESTROY {
-    my $self = shift;
-    
-    #
-    # Should disconnect our dbh clone if we created one.
-    # Otherwise, we might get annoying warning messages
-    #
-    if( $self->_lite_ready ){
-        $self->__lite->dbh->disconnect()   
-    }
 }
 
 1;

--- a/lib/MySQL/ORM/Generate/AttributeMaker.pm
+++ b/lib/MySQL/ORM/Generate/AttributeMaker.pm
@@ -33,7 +33,8 @@ method make_attribute (
 	Str      :$default,
 	Bool     :$no_init_arg,
 	Bool     :$lazy,
-	Str      :$builder
+	Str      :$builder,
+	Bool     :$required
   ) {
 
 	my $text;
@@ -50,6 +51,7 @@ method make_attribute (
 	$text .= "default => $default,\n" if $default;
 	$text .= "lazy => 1,\n" if $lazy;
 	$text .= "builder => '$builder',\n" if $builder;
+	$text .= "required => 1,\n" if $required;
 	$text .= ");\n";
 
 	return $text;

--- a/lib/MySQL/ORM/Generate/Class/Db.pm
+++ b/lib/MySQL/ORM/Generate/Class/Db.pm
@@ -158,7 +158,7 @@ method _get_build_table_body {
     	}
     
     	load $want_class;
-    	return $want_class->new(dbh => $self->dbh, schema_name => $self->db_name);
+    	return $want_class->new(dbh => $self->dbh, schema_name => $self->db_name, db => $self);
 	';
 
 	return $body;

--- a/lib/MySQL/ORM/Generate/Class/Table.pm
+++ b/lib/MySQL/ORM/Generate/Class/Table.pm
@@ -95,6 +95,14 @@ method generate {
 		no_init_arg => 1,
 		default     => sprintf( "'%s'", $self->table->name ),
 	  );
+	  
+	push @attr,
+      $self->attribute_maker->make_attribute(
+        name        => 'db',
+        is          => 'ro',
+        isa         => $self->db_class_name,
+        required    => 1
+      );
 
 	$self->writer->write_class(
 		file_name  => $self->get_module_path,
@@ -491,6 +499,10 @@ method _get_table2alias_map {
 			schema_name => $t->schema_name,
 			table_name  => $t->name
 		);
+		
+		# Skip this table if it is ourself
+		next if $parent_table_name eq $self->_get_table_name;
+		
 		$map{$parent_table_name} = 't' . $num;
 		$num++;
 	}
@@ -519,6 +531,8 @@ method _get_method_selectx {
 			schema_name => $t->schema_name,
 			table_name  => $t->name
 		);
+		
+		next if( $parent_table_name eq $self->_get_table_name );
 
 		foreach my $c ( $t->get_columns ) {
 			if ( !$arg2table{ $c->name } ) {
@@ -540,6 +554,8 @@ method _get_method_selectx {
 				schema_name => $con->parent_schema_name,
 				table_name  => $con->parent_table_name
 			);
+			
+			next if( $parent_table_name eq $self->_get_table_name );
 
 			push @from, 'left join';
 			push @from,

--- a/t/20-foo-testmysqlorm.t
+++ b/t/20-foo-testmysqlorm.t
@@ -119,6 +119,10 @@ sub check {
 	
 	@rows = $team->select;
 	ok(!@rows);
+	
+	# Test selectx for self referencing table
+	@rows = $orm->SelfRefTest->selectx( self_ref_test_code => 'self_ref_test_code1' );
+	ok( @rows == 1 );
 }
 
 sub get_random_owner_id {

--- a/t/sql
+++ b/t/sql
@@ -132,6 +132,35 @@ LOCK TABLES `team` WRITE;
 UNLOCK TABLES;
 
 --
+-- Table structure for table `self_ref_test`
+--
+
+DROP TABLE IF EXISTS `self_ref_test`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `self_ref_test` (
+  `self_ref_test_id` int(11) NOT NULL AUTO_INCREMENT,
+  `parent_self_ref_test_id` int(11),
+  `self_ref_test_code` varchar(20) NOT NULL,
+  `self_ref_test_name` varchar(20) NOT NULL,
+  PRIMARY KEY (`self_ref_test_id`),
+  UNIQUE KEY `self_ref_test_ak` (`self_ref_test_code`),
+  KEY `parent_self_ref_test_id` (`parent_self_ref_test_id`),
+  CONSTRAINT `self_ref_fk_1` FOREIGN KEY (`parent_self_ref_test_id`) REFERENCES `self_ref_test` (`self_ref_test_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `self_ref_test`
+--
+
+LOCK TABLES `self_ref_test` WRITE;
+/*!40000 ALTER TABLE `self_ref_test` DISABLE KEYS */;
+INSERT INTO `self_ref_test` VALUES (1,null,'self_ref_test_code1','self_ref_test_name1');
+/*!40000 ALTER TABLE `self_ref_test` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Current Database: `testmysqlorm_fk`
 --
 
@@ -164,6 +193,7 @@ LOCK TABLES `fk_test` WRITE;
 INSERT INTO `fk_test` VALUES (1,'fk_test_code1','fk_test_name1');
 /*!40000 ALTER TABLE `fk_test` ENABLE KEYS */;
 UNLOCK TABLES;
+
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;


### PR DESCRIPTION
- Added a db attribute to the table classes in order to maintain a link
  back to the orm class. Mainly useful in CustomRoles which want to make
  use of methods defined in other CustomRoles on different tables.
- Fixed selectx method generation to handle self referencing tables.
  Current solution was to not support selectx fetching the parent table
  attributes when the parent table == current table.