### PR TITLE
Pass __lite on table object creation.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for MySQL-ORM
 
 =======
+0.17    - Pass __lite on table creation to avoid excessive dbh->clone calls which
+          can result in large numbers of database connections being used.
+
 0.16    - Don't add column to ResultX class if it already exists in Result.
           Example, current table has column called "enabled" and parent table has column
           "enabled". In these cases, we shouldn't add "enabled" to the ResultX

--- a/lib/MySQL/ORM.pm
+++ b/lib/MySQL/ORM.pm
@@ -9,7 +9,7 @@ use Data::Printer alias => 'pdump';
 use SQL::Abstract::Complete;
 use MySQL::Util::Lite;
 
-our $VERSION = '0.16';
+our $VERSION = '0.17';
 
 =head1 SYNOPSIS
 

--- a/lib/MySQL/ORM/Generate/Class/Db.pm
+++ b/lib/MySQL/ORM/Generate/Class/Db.pm
@@ -158,7 +158,7 @@ method _get_build_table_body {
     	}
     
     	load $want_class;
-    	return $want_class->new(dbh => $self->dbh, schema_name => $self->db_name, db => $self);
+    	return $want_class->new(dbh => $self->dbh, schema_name => $self->db_name, db => $self, __lite => $self->__lite );
 	';
 
 	return $body;


### PR DESCRIPTION
This avoids excessive calls to dbh->clone.  Without this, large
numbers of database connections can be opened and eventually
exhausting the number of allowed db connections.